### PR TITLE
remove `rtt-target` from `vl53l1-reg`

### DIFF
--- a/lib/vl53l1-reg/Cargo.toml
+++ b/lib/vl53l1-reg/Cargo.toml
@@ -13,5 +13,3 @@ edition = "2018"
 [dependencies]
 bitfield = "0.13.2"
 embedded-hal = "0.2.4"
-# TODO remove this
-rtt-target = { version = "0.2.0", features = ["cortex-m"] }


### PR DESCRIPTION
this dependency is not actually used in the crate but it's present in the released version of the crate. this leads to additional unnecessary dependencies in the consumers of this crate.