### PR TITLE
Support embedded-hal v1.0

### DIFF
--- a/lib/vl53l1-reg/Cargo.toml
+++ b/lib/vl53l1-reg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vl53l1-reg"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A crate for low-level access to the registers on the VL53L1X."
 readme = "../../README.md"
@@ -12,4 +12,4 @@ edition = "2018"
 
 [dependencies]
 bitfield = "0.14"
-embedded-hal = "0.2.4"
+embedded-hal = "1.0.0"

--- a/lib/vl53l1-reg/src/lib.rs
+++ b/lib/vl53l1-reg/src/lib.rs
@@ -24,7 +24,7 @@ mod map;
 pub mod settings;
 pub mod structs;
 
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c::I2c;
 pub use map::*;
 pub use structs::Entries;
 
@@ -60,7 +60,7 @@ pub const SLAVE_ADDR: u8 = 0x52 >> 1;
 /// **Panic**s if `slice.len()` is greater than `MAX_SLICE_LEN`.
 pub fn write_slice<I>(i2c: &mut I, index: Index, slice: &[u8]) -> Result<(), I::Error>
 where
-    I: i2c::Write,
+    I: I2c,
 {
     assert!(slice.len() < MAX_SLICE_LEN);
     let mut data = [0u8; DATA_LEN];
@@ -89,7 +89,7 @@ where
 /// read.
 pub fn read_slice<I>(i2c: &mut I, index: Index, slice: &mut [u8]) -> Result<(), I::Error>
 where
-    I: i2c::WriteRead,
+    I: I2c,
 {
     let arr: [u8; 2] = index.into();
     i2c.write_read(SLAVE_ADDR, &arr, slice)
@@ -98,7 +98,7 @@ where
 /// Shorthand for writing a slice with a single byte.
 pub fn write_byte<I>(i2c: &mut I, index: Index, byte: u8) -> Result<(), I::Error>
 where
-    I: i2c::Write,
+    I: I2c,
 {
     write_slice(i2c, index, &[byte])
 }
@@ -106,7 +106,7 @@ where
 /// Shorthand for reading a single byte from the register at the given index.
 pub fn read_byte<I>(i2c: &mut I, index: Index) -> Result<u8, I::Error>
 where
-    I: i2c::WriteRead,
+    I: I2c,
 {
     let mut b = [0u8];
     read_slice(i2c, index, &mut b)?;
@@ -117,7 +117,7 @@ where
 /// Shorthand for writing a slice with a single word.
 pub fn write_word<I>(i2c: &mut I, index: Index, word: u16) -> Result<(), I::Error>
 where
-    I: i2c::Write,
+    I: I2c,
 {
     let [a, b] = word.to_be_bytes();
     write_slice(i2c, index, &[a, b])
@@ -126,7 +126,7 @@ where
 /// Shorthand for reading two consecutive bytes from the given index.
 pub fn read_word<I>(i2c: &mut I, index: Index) -> Result<u16, I::Error>
 where
-    I: i2c::WriteRead,
+    I: I2c,
 {
     let mut bs = [0u8; 2];
     read_slice(i2c, index, &mut bs)?;
@@ -136,7 +136,7 @@ where
 /// Read the the given entry.
 pub fn write_entry<I, E>(i2c: &mut I, entry: E) -> Result<(), I::Error>
 where
-    I: i2c::Write,
+    I: I2c,
     E: Entry,
 {
     let arr = entry.into_array();
@@ -146,7 +146,7 @@ where
 /// Read the value for a single entry.
 pub fn read_entry<I, E>(i2c: &mut I) -> Result<E, I::Error>
 where
-    I: i2c::WriteRead,
+    I: I2c,
     E: Entry,
 {
     let mut arr: E::Array = Default::default();

--- a/lib/vl53l1-reg/src/structs.rs
+++ b/lib/vl53l1-reg/src/structs.rs
@@ -1,4 +1,4 @@
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c::I2c;
 
 /// A struct of contiguous entries within the register map.
 pub trait Entries: Sized {
@@ -19,12 +19,12 @@ pub trait Entries: Sized {
     /// Implemented in terms of `write_to_slice`.
     fn write<I>(&self, i2c: &mut I) -> Result<(), I::Error>
     where
-        I: i2c::Write;
+        I: I2c;
 
     /// Read a new instance of the `Entries` struct from I2C.
     fn read<I>(i2c: &mut I) -> Result<Self, I::Error>
     where
-        I: i2c::WriteRead;
+        I: I2c;
 }
 
 /// Interpolates the register entries struct to generate I2C read/write methods.
@@ -57,7 +57,7 @@ macro_rules! entries_struct {
 
             fn write<I>(&self, i2c: &mut I) -> Result<(), I::Error>
             where
-                I: i2c::Write,
+                I: I2c,
             {
                 let mut bs = [0u8; Self::LEN_BYTES];
                 self.write_to_slice(&mut bs);
@@ -66,7 +66,7 @@ macro_rules! entries_struct {
 
             fn read<I>(i2c: &mut I) -> Result<Self, I::Error>
             where
-                I: i2c::WriteRead,
+                I: I2c,
             {
                 let mut bs = [0u8; Self::LEN_BYTES];
                 crate::read_slice(i2c, Self::INDEX, &mut bs).map(|()| {

--- a/lib/vl53l1/Cargo.toml
+++ b/lib/vl53l1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vl53l1"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A pure-Rust port of the official ST VL53L1X ToF sensor C API."
 readme = "../../README.md"
@@ -12,10 +12,10 @@ edition = "2018"
 
 [dependencies]
 bitfield = "0.14"
-embedded-hal = "0.2.4"
+embedded-hal = "1.0.0"
 nb = "1"
 ufmt = { version = "0.1.0", optional = true }
-vl53l1-reg = { version = "0.1", path = "../vl53l1-reg" }
+vl53l1-reg = { version = "0.2", path = "../vl53l1-reg" }
 
 # TODO
 # [features]


### PR DESCRIPTION
I am not sure if this PR is expected yet because most of stm32yyxx-hal crates are still using embedded-hal 0.2. Just let it here in case someone wants to use it.

Since 1.0, embedded-hal has unified multiple traits of same peripheral into one trait. This PR updates I2c and DelayNs traits.
https://github.com/rust-embedded/embedded-hal/blob/master/docs/migrating-from-0.2-to-1.0.md#trait-unification
